### PR TITLE
Fix LT handling in Konami Code

### DIFF
--- a/konami_code/konami_code.c
+++ b/konami_code/konami_code.c
@@ -22,7 +22,10 @@ bool process_record_konami_code(uint16_t keycode, keyrecord_t *record) {
             case QK_MOD_TAP ... QK_MOD_TAP_MAX:
                 return process_record_konami_code(QK_MOD_TAP_GET_TAP_KEYCODE(keycode), record);
             case QK_LAYER_TAP ... QK_LAYER_TAP_MAX:
-                return process_record_konami_code(QK_LAYER_TAP_GET_TAP_KEYCODE(keycode), record);
+                if (record->tap.count) {
+                    return process_record_konami_code(QK_LAYER_TAP_GET_TAP_KEYCODE(keycode), record);
+                }
+                break;
             case QK_SWAP_HANDS ... QK_SWAP_HANDS_MAX:
                 return process_record_konami_code(QK_SWAP_HANDS_GET_TAP_KEYCODE(keycode), record);
             case KC_KP_ENTER:


### PR DESCRIPTION
Minor issue, but LT resets the sequence because it's reporting the basic keycode on key release, even if it's being used as a layer key.  

Ran into this because my arrow keys are on a layer accessed with `LT(x, KC_DEL)`.   Can confirm this change fixes the issue.